### PR TITLE
feat: rewrite for more complex types, including unions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "debc29dde2e69f9e47506b525f639ed42300fc014a3e007832592448fa8e4599"
 
 [[package]]
+name = "atomic_refcell"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "857253367827bd9d0fd973f0ef15506a96e79e41b0ad7aa691203a4e3214f6c8"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,6 +754,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cbor4ii"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544cf8c89359205f4f990d0e6f3828db42df85b5dac95d09157a250eb0749c4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,6 +838,20 @@ checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cid"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ed9c8b2d17acb8110c46f1da5bf4a696d745e1474a16db0cd2b49cd0249bf2"
+dependencies = [
+ "core2",
+ "multibase",
+ "multihash 0.16.3",
+ "serde",
+ "serde_bytes",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -1492,6 +1521,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "diesel_migrations"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9ae22beef5e9d6fab9225ddb073c1c6c1a7a6ded5019d5da11d1e5c5adc34e2"
+dependencies = [
+ "diesel",
+ "migrations_internals",
+ "migrations_macros",
 ]
 
 [[package]]
@@ -2441,6 +2481,7 @@ dependencies = [
  "criterion",
  "derive_more",
  "diesel",
+ "diesel_migrations",
  "dotenvy",
  "env_logger",
  "ipfs-api",
@@ -2474,12 +2515,14 @@ name = "ipvm-wasm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "atomic_refcell",
  "criterion",
  "heck",
  "itertools",
  "libipld",
  "libipld-core 0.16.0",
  "rust_decimal",
+ "serde_ipld_dagcbor",
  "stacker",
  "thiserror",
  "tokio",
@@ -3261,6 +3304,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "migrations_internals"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c493c09323068c01e54c685f7da41a9ccf9219735c3766fbfd6099806ea08fbc"
+dependencies = [
+ "serde",
+ "toml",
+]
+
+[[package]]
+name = "migrations_macros"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a8ff27a350511de30cdabb77147501c36ef02e0451d957abea2f30caffb2b58"
+dependencies = [
+ "migrations_internals",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3330,6 +3394,19 @@ dependencies = [
  "base-x",
  "data-encoding",
  "data-encoding-macro",
+]
+
+[[package]]
+name = "multihash"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
+dependencies = [
+ "core2",
+ "multihash-derive",
+ "serde",
+ "serde-big-array",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -4699,6 +4776,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_ipld_dagcbor"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e23de7a4a18dff77ab9531f279a882500b8cf3549fde044d4e10481b411f1e"
+dependencies = [
+ "cbor4ii",
+ "cid 0.8.6",
+ "scopeguard",
+ "serde",
 ]
 
 [[package]]

--- a/ipvm-wasm/Cargo.toml
+++ b/ipvm-wasm/Cargo.toml
@@ -22,11 +22,13 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = "1.0"
+atomic_refcell = "0.1"
 heck = "0.4"
 itertools = "0.10"
 libipld = "0.16"
 libipld-core = { version = "0.16", features = ["serde-codec", "serde"] }
 rust_decimal = "1.28"
+serde_ipld_dagcbor = "0.2"
 stacker = "0.1"
 thiserror = "1.0"
 tracing = "0.1"

--- a/ipvm-wasm/src/wasmtime/ipld.rs
+++ b/ipvm-wasm/src/wasmtime/ipld.rs
@@ -28,20 +28,15 @@ use std::{
 use wasmtime::component::{Type, Val};
 
 /// Interface-type wrapper over wasmtime component [wasmtime::component::Type].
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub enum InterfaceType<'a> {
     /// Works for `any` [wasmtime::component::Type].
+    #[default]
     Any,
     /// Wraps [wasmtime::component::Type].
     Type(Type),
     /// Wraps [wasmtime::component::Type] ref.
     TypeRef(&'a Type),
-}
-
-impl Default for InterfaceType<'_> {
-    fn default() -> Self {
-        InterfaceType::Any
-    }
 }
 
 impl InterfaceType<'_> {

--- a/ipvm/Cargo.toml
+++ b/ipvm/Cargo.toml
@@ -32,6 +32,7 @@ async-trait = "0.1"
 clap = { version = "4.1", features = ["derive"] }
 derive_more = "0.99"
 diesel = { version = "2.0", features = ["sqlite"] }
+diesel_migrations = "2.0"
 dotenvy = "0.15"
 env_logger = "0.10"
 ipfs-api = "0.17"

--- a/ipvm/src/test_utils/db.rs
+++ b/ipvm/src/test_utils/db.rs
@@ -1,0 +1,13 @@
+use diesel::{connection::SimpleConnection, Connection, SqliteConnection};
+
+pub fn setup() -> anyhow::Result<SqliteConnection> {
+    let mut conn = diesel::sqlite::SqliteConnection::establish(":memory:").unwrap();
+    let source = diesel_migrations::FileBasedMigrations::find_migrations_directory()?;
+    let _ = diesel_migrations::MigrationHarness::run_pending_migrations(&mut conn, source).unwrap();
+    begin(&mut conn)?;
+    Ok(conn)
+}
+
+pub fn begin(conn: &mut SqliteConnection) -> Result<(), diesel::result::Error> {
+    conn.batch_execute("BEGIN;")
+}

--- a/ipvm/src/test_utils/mod.rs
+++ b/ipvm/src/test_utils/mod.rs
@@ -3,3 +3,6 @@
 mod rvg;
 #[cfg(feature = "test_utils")]
 pub use rvg::*;
+
+#[cfg(test)]
+pub mod db;

--- a/ipvm/tests/integration_test.rs
+++ b/ipvm/tests/integration_test.rs
@@ -1,4 +1,0 @@
-#[test]
-fn test_add() {
-    assert!(true);
-}


### PR DESCRIPTION
feat(ipld/wit): keep around tags for keyed representation vs kinded, use rc<refcell>
for interior mutability of vecdeque stack

fix(ipld/wit): more type-checking in general

refactor(ipld/wit): refactor to use refs more often

refactor(tests): way more tests and utils for testing, even db work for receipts

refactor(ipld/wit): threading store, linker